### PR TITLE
[MERGE] ge03_team07: fix the name generation for motorcycle products.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+DS_Store
 
 # C extensions
 *.so

--- a/ge03_team07/__manifest__.py
+++ b/ge03_team07/__manifest__.py
@@ -14,4 +14,5 @@
     "author": "team7",
     "website": "www.odoo.com",
     "application": False,
+    "auto_install": True,
 }

--- a/ge03_team07/models/motorcycle_name_generation.py
+++ b/ge03_team07/models/motorcycle_name_generation.py
@@ -7,4 +7,4 @@ class ProductTemplate(models.Model):
     @api.depends('make','model','year','detailed_type')
     def _compute_name(self):
         for record in self.filtered_domain([('detailed_type','=','motorcycle')]):
-            record.name= str(record.year[:2]) + str(record.make[:2]) + str(record.model[:2])
+            record.name= str(record.year)[:2] + str(record.make)[:2] + str(record.model)[:2]

--- a/ge03_team07/models/motorcycle_name_generation.py
+++ b/ge03_team07/models/motorcycle_name_generation.py
@@ -7,4 +7,4 @@ class ProductTemplate(models.Model):
     @api.depends('make','model','year','detailed_type')
     def _compute_name(self):
         for record in self.filtered_domain([('detailed_type','=','motorcycle')]):
-            record.name= str(record.year) + str(record.make) + str(record.model)
+            record.name= str(record.year[:2]) + str(record.make[:2]) + str(record.model[:2])


### PR DESCRIPTION
The name generation module was taking more than the two first characters from the fields make, model and year.